### PR TITLE
Pubsub without grpc streaming

### DIFF
--- a/google-cloud-clients/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
+++ b/google-cloud-clients/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/SubscriptionAdminClientTest.java
@@ -56,7 +56,6 @@ import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.PushConfig;
-import com.google.pubsub.v1.ReceivedMessage;
 import com.google.pubsub.v1.Snapshot;
 import com.google.pubsub.v1.StreamingPullRequest;
 import com.google.pubsub.v1.StreamingPullResponse;
@@ -456,10 +455,7 @@ public class SubscriptionAdminClientTest {
   @Test
   @SuppressWarnings("all")
   public void streamingPullTest() throws Exception {
-    ReceivedMessage receivedMessagesElement = ReceivedMessage.newBuilder().build();
-    List<ReceivedMessage> receivedMessages = Arrays.asList(receivedMessagesElement);
-    StreamingPullResponse expectedResponse =
-        StreamingPullResponse.newBuilder().addAllReceivedMessages(receivedMessages).build();
+    StreamingPullResponse expectedResponse = StreamingPullResponse.newBuilder().build();
     mockSubscriber.addResponse(expectedResponse);
     ProjectSubscriptionName subscription =
         ProjectSubscriptionName.of("[PROJECT]", "[SUBSCRIPTION]");


### PR DESCRIPTION
Regenerate Pubsub client (proto + grpc + gapic dirs), then format output.

Using googleapis without [grpc_streaming](https://github.com/googleapis/googleapis/blob/a207551d5190d2dc915ea261f19ce83eeee000d3/google/pubsub/v1/pubsub_gapic.yaml#L249).